### PR TITLE
Changes to support kubecf

### DIFF
--- a/.final_builds/packages/cf-cli-6-linux/index.yml
+++ b/.final_builds/packages/cf-cli-6-linux/index.yml
@@ -1,0 +1,6 @@
+builds:
+  ca0f17c83f5a19e7a76de8e39d08bbe87aedb94f:
+    version: ca0f17c83f5a19e7a76de8e39d08bbe87aedb94f
+    blobstore_id: 0fd37f5c-9f28-4d5f-5d81-5af0cb7ffa7b
+    sha1: f352a9f895c8233bc4e4bf0f6e88065ea79a3283
+format-version: "2"

--- a/jobs/nfsbrokerpush/spec
+++ b/jobs/nfsbrokerpush/spec
@@ -14,6 +14,7 @@ templates:
 
 packages:
   - nfsbroker
+  - cf-cli-6-linux
 
 consumes:
   - name: credhub

--- a/jobs/nfsbrokerpush/spec
+++ b/jobs/nfsbrokerpush/spec
@@ -10,6 +10,7 @@ templates:
   services.json.erb: config/services.json
   start.sh.erb: start.sh
   uaa_ca.crt.erb: uaa_ca.crt
+  bpm.yml.erb: config/bpm.yml
 
 packages:
   - nfsbroker

--- a/jobs/nfsbrokerpush/templates/bpm.yml.erb
+++ b/jobs/nfsbrokerpush/templates/bpm.yml.erb
@@ -1,0 +1,3 @@
+processes:
+  - name: nfsbrokerpush
+    executable: /var/vcap/jobs/nfsbrokerpush/bin/run

--- a/jobs/nfsv3driver/spec
+++ b/jobs/nfsv3driver/spec
@@ -7,7 +7,7 @@ templates:
   client.key.erb: config/certs/client.key
   server.crt.erb: config/certs/server.crt
   server.key.erb: config/certs/server.key
-  install.erb: bin/pre-start
+  install.erb: bin/install
   ctl.erb: bin/nfsv3driver_ctl
   start.sh.erb: bin/start.sh
   drain.erb: bin/drain

--- a/jobs/nfsv3driver/spec
+++ b/jobs/nfsv3driver/spec
@@ -11,6 +11,7 @@ templates:
   ctl.erb: bin/nfsv3driver_ctl
   start.sh.erb: bin/start.sh
   drain.erb: bin/drain
+  bpm.yml.erb: config/bpm.yml
 
 packages:
 - nfs-debs

--- a/jobs/nfsv3driver/templates/bpm.yml.erb
+++ b/jobs/nfsv3driver/templates/bpm.yml.erb
@@ -1,0 +1,10 @@
+processes:
+- name: nfsv3driver
+  executable: /var/vcap/jobs/nfsv3driver/bin/start.sh
+  hooks:
+    pre_start: /var/vcap/jobs/nfsv3driver/bin/pre-start
+  additional_volumes:
+  - path: /var/vcap/data/voldrivers
+    writable: true
+  unsafe:
+    privileged: true

--- a/jobs/nfsv3driver/templates/bpm.yml.erb
+++ b/jobs/nfsv3driver/templates/bpm.yml.erb
@@ -2,7 +2,7 @@ processes:
 - name: nfsv3driver
   executable: /var/vcap/jobs/nfsv3driver/bin/start.sh
   hooks:
-    pre_start: /var/vcap/jobs/nfsv3driver/bin/pre-start
+    pre_start: /var/vcap/jobs/nfsv3driver/bin/install
   additional_volumes:
   - path: /var/vcap/data/voldrivers
     writable: true

--- a/jobs/nfsv3driver/templates/start.sh.erb
+++ b/jobs/nfsv3driver/templates/start.sh.erb
@@ -30,6 +30,10 @@ ENABLE_INSECURE_SKIP_VERIFY=""
 ENABLE_INSECURE_SKIP_VERIFY="--insecureSkipVerify"
 <% end %>
 
+# Spawn things needed for NFS
+/sbin/rpcbind -w
+/usr/sbin/rpc.statd --no-syslog
+
 exec /var/vcap/packages/nfsv3driver/bin/nfsv3driver \
   --listenAddr="<%= p("nfsv3driver.listen_addr") %>" \
   --transport="tcp-json" \
@@ -49,5 +53,3 @@ exec /var/vcap/packages/nfsv3driver/bin/nfsv3driver \
   --logLevel="<%= p("nfsv3driver.log_level") %>" \
   --timeFormat="<%= p("nfsv3driver.log_time_format") %>" \
   --mapfsPath="<%= link("mapfs").p("path") %>" \
-  >> $LOG_DIR/nfsv3driver.stdout.log \
-  2>> $LOG_DIR/nfsv3driver.stderr.log

--- a/packages/cf-cli-6-linux/spec.lock
+++ b/packages/cf-cli-6-linux/spec.lock
@@ -1,0 +1,2 @@
+name: cf-cli-6-linux
+fingerprint: ca0f17c83f5a19e7a76de8e39d08bbe87aedb94f

--- a/packages/openldap/packaging
+++ b/packages/openldap/packaging
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 set -e # exit immediately if a simple command exits with a non-zero status
 set -u # report the usage of uninitialized variables
 
@@ -13,7 +14,15 @@ cd $BOSH_COMPILE_TARGET
 tar -xzvf openldap/openldap-2.4.44.tgz
 cd openldap-2.4.44
 
+# We don't have groff (which provides soelim) in the stemcell; since that's only
+# used to generate documentation (that we don't care about) anyway, just make a
+# stub that doesn't do anything useful.
+mkdir -p "${HOME}/bin"
+ln -s /usr/bin/true "${HOME}/bin/soelim"
+export PATH="${PATH}:${HOME}/bin"
+
 export CPPFLAGS="-I ${BDB_PATH}/include"
+export LDFLAGS="-L${BDB_PATH}/lib"
 export LD_LIBRARY_PATH="${BDB_PATH}/lib"
 ./configure --prefix=${BOSH_INSTALL_TARGET}
 


### PR DESCRIPTION
This PR contains the initial changes to support https://github.com/cloudfoundry-incubator/kubecf/issues/382.

This will also need changes to `mapfs-release` (to be BPM-compatible), plus KubeCF-side changes to use this code.  It also requires some sort of resolution for https://github.com/cloudfoundry-incubator/quarks-operator/issues/963.

Hopefully the commit messages are clear enough to be able to explain why they are needed.